### PR TITLE
add register-telemetry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ up:
 
 .PHONY: down
 down:
-	docker compose down
+	docker compose down --remove-orphans
 
 .PHONY:clean-pre-commit
 clean-pre-commit: ## removes pre-commit hook

--- a/helixtelemetry/telemetry/context/telemetry_context.py
+++ b/helixtelemetry/telemetry/context/telemetry_context.py
@@ -12,7 +12,7 @@ from helixtelemetry.telemetry.structures.telemetry_tracers import TelemetryTrace
 
 @dataclasses.dataclass
 class TelemetryContext(DataClassJsonMixin):
-    provider: TelemetryProvider
+    provider: str
     """ Provider for the telemetry context """
 
     service_name: str

--- a/helixtelemetry/telemetry/factory/telemetry_factory.py
+++ b/helixtelemetry/telemetry/factory/telemetry_factory.py
@@ -1,12 +1,8 @@
 from typing import Any, Dict, Optional, Type, Callable
 
-from helixtelemetry.telemetry.providers.console_telemetry import ConsoleTelemetry
-from helixtelemetry.telemetry.providers.null_telemetry import NullTelemetry
-from helixtelemetry.telemetry.providers.open_telemetry import OpenTelemetry
 from helixtelemetry.telemetry.providers.telemetry import Telemetry
 from helixtelemetry.telemetry.spans.telemetry_span_creator import TelemetrySpanCreator
 from helixtelemetry.telemetry.structures.telemetry_parent import TelemetryParent
-from helixtelemetry.telemetry.structures.telemetry_provider import TelemetryProvider
 
 
 class TelemetryFactory:
@@ -75,28 +71,13 @@ class TelemetryFactory:
 
         :return: telemetry instance
         """
-        if not self.telemetry_parent.telemetry_context:
-            return NullTelemetry(
-                telemetry_context=self.telemetry_parent.telemetry_context
-            )
-
-        match self.telemetry_parent.telemetry_context.provider:
-            case TelemetryProvider.CONSOLE:
-                return ConsoleTelemetry(
-                    telemetry_context=self.telemetry_parent.telemetry_context,
-                    log_level=log_level,
-                )
-            case TelemetryProvider.OPEN_TELEMETRY:
-                return OpenTelemetry(
-                    telemetry_context=self.telemetry_parent.telemetry_context,
-                    log_level=log_level,
-                )
-            case TelemetryProvider.NULL:
-                return NullTelemetry(
-                    telemetry_context=self.telemetry_parent.telemetry_context
-                )
-            case _:
-                raise ValueError("Invalid telemetry provider")
+        assert (
+            self.telemetry_parent.telemetry_context.provider in self._registry
+        ), f"Telemetry {self.telemetry_parent.telemetry_context.provider} not found in registry.  Did you register a class for it using register_telemetry_class()?"
+        return self._registry[self.telemetry_parent.telemetry_context.provider](
+            telemetry_context=self.telemetry_parent.telemetry_context,
+            log_level=log_level,
+        )
 
     def create_telemetry_span_creator(
         self, *, log_level: Optional[str | int]

--- a/helixtelemetry/telemetry/providers/console_telemetry.py
+++ b/helixtelemetry/telemetry/providers/console_telemetry.py
@@ -13,6 +13,7 @@ from typing import (
     List,
     Union,
     Mapping,
+    ClassVar,
 )
 
 from opentelemetry.metrics import NoOpCounter, NoOpUpDownCounter, NoOpHistogram
@@ -40,6 +41,8 @@ from helixtelemetry.telemetry.structures.telemetry_parent import TelemetryParent
 
 
 class ConsoleTelemetry(Telemetry):
+    telemetry_provider: ClassVar[str] = "ConsoleTelemetry"
+
     _CONTEXT_KEY = "current_context"
     _telemetry_history: List[ConsoleTelemetryHistoryItem] = []
     _current_context_variable: ContextVar[Optional[TelemetryParent]] = ContextVar(
@@ -56,7 +59,10 @@ class ConsoleTelemetry(Telemetry):
         telemetry_context: TelemetryContext,
         log_level: Optional[Union[int, str]],
     ) -> None:
-        self._telemetry_context: TelemetryContext = telemetry_context
+        super().__init__(
+            telemetry_context=telemetry_context,
+            log_level=log_level,
+        )
         self._logger: Logger = logging.getLogger(__name__)
         # get_logger sets the log level to the environment variable LOGLEVEL if it exists
         self._logger.setLevel(log_level or "INFO")

--- a/helixtelemetry/telemetry/providers/null_telemetry.py
+++ b/helixtelemetry/telemetry/providers/null_telemetry.py
@@ -1,6 +1,17 @@
+import logging
 from contextlib import contextmanager, asynccontextmanager
-from typing import Optional, Dict, Any, Iterator, AsyncIterator, override, Mapping
-
+from logging import Logger
+from typing import (
+    Optional,
+    Dict,
+    Any,
+    Iterator,
+    AsyncIterator,
+    override,
+    Mapping,
+    Union,
+    ClassVar,
+)
 
 from opentelemetry.metrics import NoOpCounter, NoOpUpDownCounter, NoOpHistogram
 
@@ -24,12 +35,21 @@ from helixtelemetry.telemetry.structures.telemetry_parent import TelemetryParent
 
 
 class NullTelemetry(Telemetry):
+    telemetry_provider: ClassVar[str] = "NullTelemetry"
+
     def __init__(
         self,
         *,
         telemetry_context: TelemetryContext,
+        log_level: Optional[Union[int, str]],
     ) -> None:
-        self._telemetry_context: TelemetryContext = telemetry_context
+        super().__init__(
+            telemetry_context=telemetry_context,
+            log_level=log_level,
+        )
+        self._logger: Logger = logging.getLogger(__name__)
+        # get_logger sets the log level to the environment variable LOGLEVEL if it exists
+        self._logger.setLevel(log_level or "INFO")
 
     @override
     def track_exception(

--- a/helixtelemetry/telemetry/providers/telemetry.py
+++ b/helixtelemetry/telemetry/providers/telemetry.py
@@ -1,8 +1,9 @@
 from abc import abstractmethod, ABC
 from contextlib import asynccontextmanager, contextmanager
 
-from typing import Optional, Dict, Any, AsyncIterator, Iterator, Mapping
+from typing import Optional, Dict, Any, AsyncIterator, Iterator, Mapping, Union
 
+from helixtelemetry.telemetry.context.telemetry_context import TelemetryContext
 from helixtelemetry.telemetry.metrics.telemetry_counter import TelemetryCounter
 from helixtelemetry.telemetry.metrics.telemetry_histogram_counter import (
     TelemetryHistogram,
@@ -25,6 +26,15 @@ class Telemetry(ABC):
     Abstract class for telemetry
 
     """
+
+    def __init__(
+        self,
+        *,
+        telemetry_context: TelemetryContext,
+        log_level: Optional[Union[int, str]],
+    ) -> None:
+        self._telemetry_context: TelemetryContext = telemetry_context
+        self._log_level = log_level
 
     @abstractmethod
     @contextmanager

--- a/helixtelemetry/telemetry/register.py
+++ b/helixtelemetry/telemetry/register.py
@@ -1,0 +1,22 @@
+from helixtelemetry.telemetry.factory.telemetry_factory import TelemetryFactory
+from helixtelemetry.telemetry.providers.console_telemetry import ConsoleTelemetry
+from helixtelemetry.telemetry.providers.null_telemetry import NullTelemetry
+from helixtelemetry.telemetry.providers.open_telemetry import OpenTelemetry
+
+
+def register() -> None:
+    """
+    Register the telemetry classes with the telemetry factory
+    """
+
+    TelemetryFactory.register_telemetry_class(
+        name=NullTelemetry.telemetry_provider, telemetry_class=NullTelemetry
+    )
+    TelemetryFactory.register_telemetry_class(
+        name=ConsoleTelemetry.telemetry_provider, telemetry_class=ConsoleTelemetry
+    )
+
+    TelemetryFactory.register_telemetry_class(
+        name=OpenTelemetry.telemetry_provider,
+        telemetry_class=OpenTelemetry,
+    )

--- a/helixtelemetry/telemetry/structures/telemetry_provider.py
+++ b/helixtelemetry/telemetry/structures/telemetry_provider.py
@@ -1,7 +1,4 @@
-from enum import Enum
-
-
-class TelemetryProvider(Enum):
+class TelemetryProvider:
     CONSOLE = "console"
     OPEN_TELEMETRY = "open_telemetry"
     NULL = "null"


### PR DESCRIPTION
1. Architectural Changes:
   - The PR introduces a more flexible telemetry provider registration mechanism using a registry pattern in `TelemetryFactory`.
   - The `TelemetryProvider` is changed from an `Enum` to a simple class with string constants.
   - A new `register.py` file is added to centralize telemetry provider registration.

2. Key Modifications:
   - `telemetry_context.py`: Changed `provider` type from `TelemetryProvider` to `str`
   - `telemetry_factory.py`: Replaced match-case provider selection with a registry-based approach
   - Added class method `register_telemetry_class()` and decorator `register_telemetry()` to `TelemetryFactory`
   - Added a `telemetry_provider` class variable to each telemetry provider class
