### PR TITLE
CIE-6909 Initialize counter metric to zero on first write

### DIFF
--- a/helixtelemetry/telemetry/metrics/telemetry_counter.py
+++ b/helixtelemetry/telemetry/metrics/telemetry_counter.py
@@ -1,4 +1,4 @@
-from typing import Optional, Dict, Union, Mapping
+from typing import Optional, Dict, Union, Mapping, Set, Tuple
 
 from opentelemetry.context import Context
 from opentelemetry.metrics import Counter
@@ -28,7 +28,9 @@ class TelemetryCounter:
         self._counter: Counter = counter
         self._attributes: Optional[Mapping[str, TelemetryAttributeValue]] = attributes
         self._telemetry_parent: Optional[TelemetryParent] = telemetry_parent
-        self._initialized_time_series: Set[tuple[str, TelemetryAttributeValue]] = set()
+        self._initialized_time_series: Set[
+            Tuple[Tuple[str, TelemetryAttributeValueWithoutNone], ...]
+        ] = set()
 
     def add(
         self,
@@ -49,9 +51,7 @@ class TelemetryCounter:
         # Initialize the time series if it hasn't been initialized yet
         time_series_key = tuple(sorted(combined_attributes.items()))
         if time_series_key not in self._initialized_time_series:
-            self._counter.add(
-                amount=0, attributes=combined_attributes, context=context
-            )
+            self._counter.add(amount=0, attributes=combined_attributes, context=context)
             self._initialized_time_series.add(time_series_key)
 
         self._counter.add(

--- a/helixtelemetry/telemetry/metrics/telemetry_counter.py
+++ b/helixtelemetry/telemetry/metrics/telemetry_counter.py
@@ -28,6 +28,7 @@ class TelemetryCounter:
         self._counter: Counter = counter
         self._attributes: Optional[Mapping[str, TelemetryAttributeValue]] = attributes
         self._telemetry_parent: Optional[TelemetryParent] = telemetry_parent
+        self._initialized_time_series: Set[tuple[str, TelemetryAttributeValue]] = set()
 
     def add(
         self,
@@ -44,6 +45,14 @@ class TelemetryCounter:
                 ]
             )
         )
+
+        # Initialize the time series if it hasn't been initialized yet
+        time_series_key = tuple(sorted(combined_attributes.items()))
+        if time_series_key not in self._initialized_time_series:
+            self._counter.add(
+                amount=0, attributes=combined_attributes, context=context
+            )
+            self._initialized_time_series.add(time_series_key)
 
         self._counter.add(
             amount=amount, attributes=combined_attributes, context=context


### PR DESCRIPTION
OpenTelemetry by default uses a cumulative temporality for counter metrics. DataDog transparently converts OpenTelemetry metrics to delta temporality.

groundcover does not support delta temporality, so for counter aggregations to work correctly there needs to be an initial zero value for the time series. This should not impact DataDog as delta temporality implies an initial zero value.

Since a time series is defined by its attribute set and attributes can be specified at write time, the initialization check needs to happen a write time.