### PR TITLE
CIE-6997: Migrate from Bitnami

### DIFF
--- a/docker-compose.services.observability.yml
+++ b/docker-compose.services.observability.yml
@@ -37,7 +37,7 @@ x-clickhouse-defaults: &clickhouse-defaults
       hard: 262144
 x-zookeeper-defaults: &zookeeper-defaults
   !!merge <<: *common
-  image: bitnami/zookeeper:3.7.1
+  image: zookeeper:3.7.1
   user: root
   labels:
     signoz.io/scrape: "true"
@@ -85,7 +85,7 @@ services:
     #   - "2888:2888"
     #   - "3888:3888"
     volumes:
-      - zookeeper-1:/bitnami/zookeeper
+      - zookeeper-1:/var/lib/zookeeper
     environment:
       - ZOO_SERVER_ID=1
       - ALLOW_ANONYMOUS_LOGIN=yes


### PR DESCRIPTION
# CIE-6997: Migrate from Bitnami Images and Helm Charts

## Summary
This PR migrates away from Bitnami images and Helm charts due to their deprecation of the public catalog on Sep. 29th, 2025. Only the minimum necessary changes have been made to replace Bitnami dependencies with official alternatives.

## Key Changes
- **Docker Images**: Replaced Bitnami images with official alternatives (kafka, redis, mongodb, etc.)
- **Helm Charts**: Updated chart dependencies from charts.bitnami.com to official repositories
- **Volume Paths**: Updated mount paths to match new image structures
- **Default Credentials**: Updated from "bitnami" defaults to standard defaults where applicable

## Action Required
**Please review all Docker and Helm configuration changes carefully** - while only minimum changes were made, teams should verify:
- Local development environments still work correctly
- Staging/production deployments function as expected
- Any custom configurations or scripts that depend on Bitnami-specific paths or defaults

## Testing
- [ ] Local docker-compose environments tested
- [ ] Staging deployment verified
- [ ] Production deployment planned

---
*This migration addresses the Bitnami public catalog deprecation. For questions or issues, please reach out to CIE.*
